### PR TITLE
Fully implement render targets

### DIFF
--- a/LyraEngine/include/Entity/Components/Cubemap.h
+++ b/LyraEngine/include/Entity/Components/Cubemap.h
@@ -35,7 +35,7 @@ public:
 		std::string_view vertexShaderPath,
 		std::string_view fragShaderPath,
 		Camera* const camera,
-		const VkFormat& format,
+		const Image::Format& format,
 		const ColorBlending& colorBlending,
 		const Tessellation& tessellation,
 		const Multisampling& multisampling
@@ -54,7 +54,7 @@ public:
 	 * 
 	 * @return VkDescriptorImageInfo
 	*/
-	NODISCARD constexpr VkDescriptorImageInfo getDescriptorcubemapInfo(const VkImageLayout& layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) const noexcept {
+	NODISCARD constexpr VkDescriptorImageInfo getDescriptorcubemapInfo(const Image::Layout& layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) const noexcept {
 		return {
 			m_sampler,
 			m_view,
@@ -84,7 +84,7 @@ public:
 		const Array<std::string_view, 6>& paths,
 		Script* script,
 		Camera* const camera,
-		const VkFormat& format = VK_FORMAT_R8G8B8A8_SRGB,
+		const Image::Format& format = VK_FORMAT_R8G8B8A8_SRGB,
 		const ColorBlending& colorBlending = ColorBlending::BLEND_ENABLE,
 		const Tessellation& tessellation = Tessellation::TESSELLATION_ENABLE,
 		const Multisampling& multisampling = Multisampling::MULTISAMPLING_ENABLE
@@ -97,7 +97,7 @@ public:
 	Skybox(
 		const Array<std::string_view, 6>& paths,
 		Camera* const camera,
-		const VkFormat& format = VK_FORMAT_R8G8B8A8_SRGB,
+		const Image::Format& format = VK_FORMAT_R8G8B8A8_SRGB,
 		const ColorBlending& colorBlending = ColorBlending::BLEND_ENABLE,
 		const Tessellation& tessellation = Tessellation::TESSELLATION_ENABLE,
 		const Multisampling& multisampling = Multisampling::MULTISAMPLING_ENABLE

--- a/LyraEngine/include/Graphics/Mesh.h
+++ b/LyraEngine/include/Graphics/Mesh.h
@@ -89,16 +89,16 @@ public:
 	}
 
 	Mesh(
-		const Vector <Vertex>& vertices, 
-		const Vector <uint32>& indices
+		const Vector<Vertex>& vertices, 
+		const Vector<uint32>& indices
 	) : m_vertices(vertices), m_indices(indices) { }
 
-	NODISCARD Vector <Vertex> vertices() const noexcept { return m_vertices; }
-	NODISCARD Vector <uint32> indices() const noexcept { return m_indices; }
+	NODISCARD const Vector<Vertex>& vertices() const noexcept { return m_vertices; }
+	NODISCARD const Vector<uint32>& indices() const noexcept { return m_indices; }
 
 private:
-	Vector <Vertex> m_vertices;
-	Vector <uint32> m_indices;
+	Vector<Vertex> m_vertices;
+	Vector<uint32> m_indices;
 };
 
 } // namespace lyra

--- a/LyraEngine/include/Graphics/Texture.h
+++ b/LyraEngine/include/Graphics/Texture.h
@@ -31,13 +31,13 @@ public:
 	};
 
 	Texture() = default;
-	Texture(const resource::TextureFile& imageData, const VkFormat& format = VK_FORMAT_R8G8B8A8_SRGB);
+	Texture(const resource::TextureFile& imageData, vulkan::Image::Format format = vulkan::Image::Format::r8g8b8a8SRGB);
 
-	NODISCARD constexpr VkDescriptorImageInfo getDescriptorImageInfo(const VkImageLayout& layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) const noexcept {
+	NODISCARD constexpr VkDescriptorImageInfo getDescriptorImageInfo(vulkan::Image::Layout layout = vulkan::Image::Layout::shaderReadOnly) const noexcept {
 		return {
 			m_sampler,
-			m_image.view,
-			layout
+			m_imageResource.view,
+			static_cast<VkImageLayout>(layout)
 		};
 	}
 
@@ -45,6 +45,7 @@ public:
 
 private:
 	vulkan::Image m_image;
+	vulkan::Image::Resource m_imageResource;
 	vulkan::GPUMemory m_memory;
 	vulkan::vk::Sampler m_sampler;
 

--- a/LyraEngine/include/Input/InputEnums.h
+++ b/LyraEngine/include/Input/InputEnums.h
@@ -315,8 +315,6 @@ enum class ControllerButtonType {
 	paddle3, /* Xbox Elite paddle P2 */
 	paddle4, /* Xbox Elite paddle P4 */
 	touchpad, /* PS4/PS5 touchpad button */
-
-	maxEnum
 };
 
 } // namespace input

--- a/LyraEngine/src/Entity/Components/Cubemap.cpp
+++ b/LyraEngine/src/Entity/Components/Cubemap.cpp
@@ -17,7 +17,7 @@ CubemapBase::CubemapBase(
 	std::string_view vertexShaderPath,
 	std::string_view fragShaderPath,
 	Camera* const camera,
-	const VkFormat& format,
+	const Image::Format& format,
 	const ColorBlending& colorBlending,
 	const Tessellation& tessellation,
 	const Multisampling& multisampling
@@ -112,7 +112,7 @@ CubemapBase::CubemapBase(
 		// copy the buffer contents into the image
 		copyFromBuffer(&stagingBuffer, imageExtent);
 		
-		// finally, create the image view
+		//ly, create the image view
 		createView(format, { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6 }, VK_IMAGE_VIEW_TYPE_CUBE);
 	}
 


### PR DESCRIPTION
Seperate Images and Image views to implement the custom render targets with fully customisable attachments and subpasses.